### PR TITLE
Chore: 불필요 채택 프로토콜 삭제

### DIFF
--- a/Expo1900/Expo1900/Types/Artwork.swift
+++ b/Expo1900/Expo1900/Types/Artwork.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Artwork: Decodable, Equatable {
+struct Artwork: Decodable {
     let name: String
     let imageName: String
     let shortDescription: String

--- a/Expo1900/Expo1900/Types/ExpoIntroduction.swift
+++ b/Expo1900/Expo1900/Types/ExpoIntroduction.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ExpoIntroduction: Decodable, Equatable {
+struct ExpoIntroduction: Decodable {
     let title: String
     let visitors: Int
     let location: String


### PR DESCRIPTION
- 각 타입의 테스트에서 타입 자체가 `nil`인지 여부 검사하는 테스트 삭제
- 해당 테스트 삭제로 인해 `Equatable` 프로토콜을 채택할 필요가 없어짐