### PR TITLE
[STEP 3] 오토레이아웃 적용

### DIFF
--- a/Expo1900/Expo1900/Controller/AppDelegate.swift
+++ b/Expo1900/Expo1900/Controller/AppDelegate.swift
@@ -9,27 +9,26 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
   
+  var shouldSupportAllOrientation: Bool = false
   
+  func application(
+    _ application: UIApplication,
+    supportedInterfaceOrientationsFor window: UIWindow?
+  ) -> UIInterfaceOrientationMask {
+    if shouldSupportAllOrientation == true {
+      return  .allButUpsideDown
+    }
+    return .portrait
+  }
   
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    // Override point for customization after application launch.
     return true
   }
   
   // MARK: UISceneSession Lifecycle
   
   func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-    // Called when a new scene session is being created.
-    // Use this method to select a configuration to create the new scene with.
     return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
   }
-  
-  func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-    // Called when the user discards a scene session.
-    // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-    // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-  }
-  
-  
 }
 

--- a/Expo1900/Expo1900/Controller/ArtworkDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/ArtworkDetailViewController.swift
@@ -9,23 +9,32 @@ import UIKit
 import OSLog
 
 final class ArtworkDetailViewController: UIViewController {
-  @IBOutlet weak var artworkImageView: UIImageView!
-  @IBOutlet weak var descriptionTextView: UITextView!
+  // MARK: - Properties
+  @IBOutlet private weak var artworkImageView: UIImageView!
+  @IBOutlet private weak var descriptionTextView: UITextView!
   var artwork: Artwork?
   
+  // MARK: - Namespace
+  private enum OSLogMessage {
+    static let artworkIsNil: StaticString = "Artwork가 Nil입니다."
+  }
+  
+  // MARK: - View life cycle
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    // MARK: - Decode JSON and update UI
-    guard let artwork: Artwork = artwork else { return }
+    guard let artwork: Artwork = artwork else {
+      os_log(.fault, log: .data, OSLogMessage.artworkIsNil)
+      return
+    }
     
-    insertDataToUI(from: artwork)
+    configureUI(with: artwork)
   }
 }
 
-// MARK: - Method for inserting data to the UI elements
+// MARK: - Method for configure the UI elements
 extension ArtworkDetailViewController {
-  private func insertDataToUI(from data: Artwork) {
+  private func configureUI(with data: Artwork) {
     self.navigationItem.title = data.name
     artworkImageView.image = UIImage(named: data.imageName)
     descriptionTextView.text = data.description

--- a/Expo1900/Expo1900/Controller/ArtworkTableViewCell.swift
+++ b/Expo1900/Expo1900/Controller/ArtworkTableViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class ArtworkTableViewCell: UITableViewCell {
-  @IBOutlet private weak var thumbnailImageView: UIImageView!
-  @IBOutlet private weak var titleLabel: UILabel!
-  @IBOutlet private weak var shortDescriptionLabel: UILabel!
+  @IBOutlet weak var thumbnailImageView: UIImageView!
+  @IBOutlet weak var titleLabel: UILabel!
+  @IBOutlet weak var shortDescriptionLabel: UILabel!
 }

--- a/Expo1900/Expo1900/Controller/ArtworkTableViewCell.swift
+++ b/Expo1900/Expo1900/Controller/ArtworkTableViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class ArtworkTableViewCell: UITableViewCell {
-  @IBOutlet weak var thumbnailImageView: UIImageView!
-  @IBOutlet weak var titleLabel: UILabel!
-  @IBOutlet weak var shortDescriptionLabel: UILabel!
+  @IBOutlet private weak var thumbnailImageView: UIImageView!
+  @IBOutlet private weak var titleLabel: UILabel!
+  @IBOutlet private weak var shortDescriptionLabel: UILabel!
 }

--- a/Expo1900/Expo1900/Controller/ArtworksTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ArtworksTableViewController.swift
@@ -37,6 +37,10 @@ final class ArtworksTableViewController: UIViewController {
       debugPrint(error)
     }
   }
+  
+  override func viewWillAppear(_ animated: Bool) {
+    UINavigationController.attemptRotationToDeviceOrientation()
+  }
 }
 
 // MARK: - Table view data source

--- a/Expo1900/Expo1900/Controller/ArtworksTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ArtworksTableViewController.swift
@@ -9,13 +9,25 @@ import UIKit
 import OSLog
 
 final class ArtworksTableViewController: UIViewController {
-  @IBOutlet weak var tableView: UITableView!
+  // MARK: - Properties
+  @IBOutlet private weak var tableView: UITableView!
   private var artworks: [Artwork] = []
   
+  // MARK: - Namespace
+  private enum Identifier {
+    enum Segue {
+      static let artworkDetail: String = "showDetail"
+    }
+  }
+  
+  private enum OSLogMessage {
+    static let indexPathIsNil: StaticString = "indexPath가 nil입니다."
+  }
+  
+  // MARK: - View life cycle
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    // MARK: - Decode JSON and insert to the UI elements
     let decodedResult: Result = ExpoJSONDecoder.decode(to: [Artwork].self,from: ExpoData.artworks)
     
     switch decodedResult {
@@ -57,16 +69,15 @@ extension ArtworksTableViewController: UITableViewDelegate {
 // MARK: - View controller: segue
 extension ArtworksTableViewController {
   override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-    let indexPath = tableView.indexPathForSelectedRow
-
-    if segue.identifier == "showDetail" {
+    guard let indexPath = tableView.indexPath(for: sender as! UITableViewCell) else {
+      os_log(.fault, log: .ui, OSLogMessage.indexPathIsNil)
+      return
+    }
+    
+    if segue.identifier == Identifier.Segue.artworkDetail {
       let followingViewController = segue.destination as? ArtworkDetailViewController
-      guard let rowOfIndexPath: Int = indexPath?.row else {
-        os_log(.fault, log: .ui, "indexPath가 nil입니다.")
-        return
-      }
       
-      followingViewController?.artwork = artworks[rowOfIndexPath]
+      followingViewController?.artwork = artworks[indexPath.row]
     }
   }
 }

--- a/Expo1900/Expo1900/Controller/ArtworksTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ArtworksTableViewController.swift
@@ -18,6 +18,10 @@ final class ArtworksTableViewController: UIViewController {
     enum Segue {
       static let artworkDetail: String = "showDetail"
     }
+    
+    enum Cell {
+      static let artwork: String = "artworkTableViewCell"
+    }
   }
   
   private enum OSLogMessage {
@@ -51,7 +55,7 @@ extension ArtworksTableViewController: UITableViewDataSource {
   
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     let cell: ArtworkTableViewCell = tableView.dequeueReusableCell(
-      withIdentifier: "artworkTableViewCell",
+      withIdentifier: Identifier.Cell.artwork,
       for: indexPath
     ) as! ArtworkTableViewCell
     

--- a/Expo1900/Expo1900/Controller/ArtworksTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ArtworksTableViewController.swift
@@ -13,7 +13,7 @@ final class ArtworksTableViewController: UIViewController {
   @IBOutlet private weak var tableView: UITableView!
   private var artworks: [Artwork] = []
   
-  // MARK: - Namespace
+  // MARK: - Namespaces
   private enum Identifier {
     enum Segue {
       static let artworkDetail: String = "showDetail"

--- a/Expo1900/Expo1900/Controller/ExpoIntroductionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoIntroductionViewController.swift
@@ -23,7 +23,7 @@ final class ExpoIntroductionViewController: UIViewController {
     }
     
     enum Suffix {
-      static let visitorSuffix: String = " 명"
+      static let visitor: String = " 명"
     }
   }
 
@@ -61,7 +61,7 @@ extension ExpoIntroductionViewController {
     switch formattedNumber(data.visitors) {
     case .success(let formattedNumber):
       numberOfVisitorsLabel.text = Affix.Prefix.visitor + formattedNumber +
-        Affix.Suffix.visitorSuffix
+        Affix.Suffix.visitor
     case .failure(ExpoAppError.numberFormattingFailed(let number)):
       debugPrint(ExpoAppError.numberFormattingFailed(number))
     case .failure(_):

--- a/Expo1900/Expo1900/Controller/ExpoIntroductionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoIntroductionViewController.swift
@@ -62,7 +62,7 @@ final class ExpoIntroductionViewController: UIViewController {
 
 // MARK: - Methods for configuring the UI elements
 extension ExpoIntroductionViewController {
-  private func insertDataToNumberOfVisitorsLabel(from data: ExpoIntroduction) {
+  private func configureNumberOfVisitorsLabel(with data: ExpoIntroduction) {
     switch formattedNumber(data.visitors) {
     case .success(let formattedNumber):
       numberOfVisitorsLabel.text = Affix.Prefix.visitor + formattedNumber +
@@ -81,7 +81,7 @@ extension ExpoIntroductionViewController {
     durationLabel.text = Affix.Prefix.duration + data.duration
     descriptionTextView.text = data.description
     
-    insertDataToNumberOfVisitorsLabel(from: data)
+    configureNumberOfVisitorsLabel(with: data)
   }
   
   func formattedNumber(_ number: Int) -> Result<String, ExpoAppError> {

--- a/Expo1900/Expo1900/Controller/ExpoIntroductionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoIntroductionViewController.swift
@@ -14,6 +14,10 @@ final class ExpoIntroductionViewController: UIViewController {
   @IBOutlet private weak var locationLabel: UILabel!
   @IBOutlet private weak var durationLabel: UILabel!
   @IBOutlet private weak var descriptionTextView: UITextView!
+  override var shouldAutorotate: Bool { return false }
+  override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation { return .portrait }
+  override var supportedInterfaceOrientations: UIInterfaceOrientationMask { return .portrait }
+  private let appDelegate = UIApplication.shared.delegate as! AppDelegate
   
   // MARK: - Namespace
   private enum Affix {
@@ -46,12 +50,12 @@ final class ExpoIntroductionViewController: UIViewController {
   }
 
   override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
+    appDelegate.shouldSupportAllOrientation = false
     self.navigationController?.isNavigationBarHidden = true
   }
   
   override func viewWillDisappear(_ animated: Bool) {
-    super.viewWillDisappear(animated)
+    appDelegate.shouldSupportAllOrientation = true
     self.navigationController?.isNavigationBarHidden = false
   }
 }

--- a/Expo1900/Expo1900/Controller/ExpoIntroductionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoIntroductionViewController.swift
@@ -7,14 +7,15 @@
 import UIKit
 
 final class ExpoIntroductionViewController: UIViewController {
+  // MARK: - Properties
+  @IBOutlet private weak var titleLabel: UILabel!
+  @IBOutlet private weak var expoPosterImageView: UIImageView!
+  @IBOutlet private weak var numberOfVisitorsLabel: UILabel!
+  @IBOutlet private weak var locationLabel: UILabel!
+  @IBOutlet private weak var durationLabel: UILabel!
+  @IBOutlet private weak var descriptionTextView: UITextView!
   
-  @IBOutlet weak var titleLabel: UILabel!
-  @IBOutlet weak var expoPosterImageView: UIImageView!
-  @IBOutlet weak var numberOfVisitorsLabel: UILabel!
-  @IBOutlet weak var locationLabel: UILabel!
-  @IBOutlet weak var durationLabel: UILabel!
-  @IBOutlet weak var descriptionTextView: UITextView!
-  
+  // MARK: - Namespace
   private enum Affix {
     enum Prefix {
       static let visitor: String = "방문객: "
@@ -27,10 +28,10 @@ final class ExpoIntroductionViewController: UIViewController {
     }
   }
 
+  // MARK: - View Life Cycle
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    // MARK: - Decode JSON and insert to the UI elements
     let decodedResult: Result = ExpoJSONDecoder.decode(
       to: ExpoIntroduction.self,
       from: ExpoData.expoIntroduction
@@ -38,7 +39,7 @@ final class ExpoIntroductionViewController: UIViewController {
     
     switch decodedResult {
     case .success(let expoIntroduction):
-      insertDataToUI(with: expoIntroduction)
+      configureUI(with: expoIntroduction)
     case .failure(let error):
       debugPrint(error)
     }
@@ -55,7 +56,7 @@ final class ExpoIntroductionViewController: UIViewController {
   }
 }
 
-// MARK: - Methods for inserting data to the UI elements
+// MARK: - Methods for configuring the UI elements
 extension ExpoIntroductionViewController {
   private func insertDataToNumberOfVisitorsLabel(from data: ExpoIntroduction) {
     switch formattedNumber(data.visitors) {
@@ -69,7 +70,7 @@ extension ExpoIntroductionViewController {
     }
   }
   
-  private func insertDataToUI(with data: ExpoIntroduction) {
+  private func configureUI(with data: ExpoIntroduction) {
     titleLabel.text = data.title
     expoPosterImageView.image = UIImage(named: "poster")
     locationLabel.text = Affix.Prefix.location + data.location

--- a/Expo1900/Expo1900/Controller/ExpoIntroductionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoIntroductionViewController.swift
@@ -74,13 +74,18 @@ extension ExpoIntroductionViewController {
     }
   }
   
-  private func configureUI(with data: ExpoIntroduction) {
+  private func configureTitleLabel(with data: ExpoIntroduction) {
     titleLabel.text = data.title
+    titleLabel.text = titleLabel.text?.replacingOccurrences(of: "박람회 1900", with: "박람회 1900\n")
+  }
+  
+  private func configureUI(with data: ExpoIntroduction) {
     expoPosterImageView.image = UIImage(named: "poster")
     locationLabel.text = Affix.Prefix.location + data.location
     durationLabel.text = Affix.Prefix.duration + data.duration
     descriptionTextView.text = data.description
     
+    configureTitleLabel(with: data)
     configureNumberOfVisitorsLabel(with: data)
   }
   

--- a/Expo1900/Expo1900/Info.plist
+++ b/Expo1900/Expo1900/Info.plist
@@ -52,8 +52,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/Expo1900/Expo1900/Model/ExpoAppError.swift
+++ b/Expo1900/Expo1900/Model/ExpoAppError.swift
@@ -5,13 +5,15 @@
 //  Created by Ryan-Son on 2021/04/07.
 //
 
-enum ExpoAppError: Error, CustomDebugStringConvertible, Equatable {
+enum ExpoAppError: Error, Equatable {
   case invalidJSONFileName(String)
   case invalidJSONFormat(String)
   case foundNil(String)
   case numberFormattingFailed(Int)
   case unknownError(String)
-  
+}
+
+extension ExpoAppError: CustomDebugStringConvertible {
   var debugDescription: String {
     switch self {
     case .invalidJSONFileName(let fileName):

--- a/Expo1900/Expo1900/Model/OSLog.swift
+++ b/Expo1900/Expo1900/Model/OSLog.swift
@@ -10,4 +10,5 @@ import OSLog
 extension OSLog {
   private static var subsystem = Bundle.main.bundleIdentifier!
   static let ui = OSLog(subsystem: subsystem, category: "UI")
+  static let data = OSLog(subsystem: subsystem, category: "Data")
 }

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="naq-Zb-3j7">
-    <device id="retina5_9" orientation="portrait" appearance="light"/>
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -13,48 +13,52 @@
             <objects>
                 <viewController id="uxu-vp-Ftd" customClass="ExpoIntroductionViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Rik-HV-13y">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2al-ah-QL5">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="XTp-P7-pb7">
-                                        <rect key="frame" x="0.0" y="15" width="375" height="799.66666666666663"/>
+                                        <rect key="frame" x="0.0" y="15" width="414" height="867.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W9n-k2-cQd">
-                                                <rect key="frame" x="18.666666666666657" y="0.0" width="337.66666666666674" height="33.666666666666664"/>
+                                                <rect key="frame" x="20.5" y="0.0" width="373" height="33.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="0Mm-LZ-6Jq">
-                                                <rect key="frame" x="122.66666666666669" y="63.666666666666686" width="130" height="182"/>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0Mm-LZ-6Jq">
+                                                <rect key="frame" x="122" y="63.5" width="170" height="250"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="130" id="hlu-ZQ-FFr"/>
-                                                    <constraint firstAttribute="height" constant="182" id="tG9-O7-WYm"/>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="170" id="hlu-ZQ-FFr"/>
+                                                    <constraint firstAttribute="width" secondItem="0Mm-LZ-6Jq" secondAttribute="height" multiplier="17:25" id="pDh-5x-YFK"/>
+                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="220" id="tG9-O7-WYm"/>
                                                 </constraints>
+                                                <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="font">
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                </preferredSymbolConfiguration>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q9r-Vv-YlV">
-                                                <rect key="frame" x="18.666666666666657" y="275.66666666666669" width="337.66666666666674" height="24"/>
+                                                <rect key="frame" x="20.5" y="343.5" width="373" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DGN-wd-zEG">
-                                                <rect key="frame" x="18.666666666666657" y="329.66666666666669" width="337.66666666666674" height="24"/>
+                                                <rect key="frame" x="20.5" y="397.5" width="373" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IBO-7c-rZz">
-                                                <rect key="frame" x="18.666666666666657" y="383.66666666666669" width="337.66666666666674" height="24"/>
+                                                <rect key="frame" x="20.5" y="451.5" width="373" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6PF-sP-6bm">
-                                                <rect key="frame" x="18.666666666666657" y="437.66666666666674" width="337.66666666666674" height="302"/>
+                                                <rect key="frame" x="20.5" y="505.5" width="373" height="302"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
@@ -62,10 +66,10 @@
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="DAv-k3-Cf2">
-                                                <rect key="frame" x="18.666666666666657" y="769.66666666666663" width="337.66666666666674" height="30"/>
+                                                <rect key="frame" x="20.5" y="837.5" width="373" height="30"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="AFB-51-Nxr">
-                                                        <rect key="frame" x="0.0" y="0.0" width="85.333333333333329" height="30"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="103" height="30"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="20" id="OcA-fl-gMj"/>
                                                             <constraint firstAttribute="width" priority="750" constant="50" id="b4m-Os-V8Z"/>
@@ -73,7 +77,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="BaF-UW-Uca">
-                                                        <rect key="frame" x="95.333333333333314" y="0.0" width="147" height="30"/>
+                                                        <rect key="frame" x="113" y="0.0" width="147" height="30"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                         <state key="normal" title="한국의 출품작 보러가기"/>
                                                         <userDefinedRuntimeAttributes>
@@ -84,7 +88,7 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="UtQ-Ps-fb9">
-                                                        <rect key="frame" x="252.33333333333334" y="0.0" width="85.333333333333343" height="30"/>
+                                                        <rect key="frame" x="270" y="0.0" width="103" height="30"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="30" id="94e-Xb-2G3"/>
                                                             <constraint firstAttribute="width" priority="750" constant="70" id="WgN-d6-URw"/>
@@ -148,28 +152,28 @@
             <objects>
                 <viewController id="6nj-jU-mX6" customClass="ArtworksTableViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="YOK-4Z-Nz7">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="iAO-ZJ-Agr">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="778"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="artworkTableViewCell" id="x5F-zN-2I4" customClass="ArtworkTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="71.666664123535156"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="72"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="x5F-zN-2I4" id="DN2-Xb-7dX">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="71.666664123535156"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="72"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DvP-hq-pfF">
-                                                    <rect key="frame" x="89.333333333333329" y="8" width="243.66666666666669" height="27"/>
+                                                    <rect key="frame" x="103" y="8" width="269" height="27"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.right" catalog="system" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="V9A-UB-hih">
-                                                    <rect key="frame" x="347.66666666666669" y="22" width="12.333333333333314" height="28.000000000000004"/>
+                                                    <rect key="frame" x="386.5" y="22" width="12.5" height="28"/>
                                                     <color key="tintColor" systemColor="placeholderTextColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="12.5" id="2Tv-Vj-Vmh"/>
@@ -179,18 +183,18 @@
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                     </preferredSymbolConfiguration>
                                                 </imageView>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="500" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iFk-je-OfD">
-                                                    <rect key="frame" x="15.000000000000004" y="9" width="59.333333333333343" height="54"/>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="500" ambiguous="YES" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iFk-je-OfD">
+                                                    <rect key="frame" x="15" y="9" width="73" height="54"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="73" id="0xe-QJ-ABb"/>
-                                                        <constraint firstAttribute="height" constant="54" id="lwc-o4-U62"/>
+                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="54" id="lwc-o4-U62"/>
                                                     </constraints>
                                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="font" scale="large">
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                     </preferredSymbolConfiguration>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="500" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N0K-GJ-zUp">
-                                                    <rect key="frame" x="89.333333333333329" y="44.333333333333336" width="243.66666666666669" height="19.333333333333336"/>
+                                                    <rect key="frame" x="103" y="44.5" width="269" height="19.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -251,24 +255,25 @@
             <objects>
                 <viewController storyboardIdentifier="ArtworkDetailViewController" id="1Bi-c2-xrB" customClass="ArtworkDetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="uEi-kp-6rg">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jfZ-fw-sye">
-                                <rect key="frame" x="0.0" y="88" width="375" height="724"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="22" translatesAutoresizingMaskIntoConstraints="NO" id="FNa-JS-dAG">
-                                        <rect key="frame" x="0.0" y="20" width="375" height="474"/>
+                                        <rect key="frame" x="0.0" y="20" width="414" height="474"/>
                                         <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Qan-4E-yVI">
-                                                <rect key="frame" x="87.666666666666686" y="0.0" width="200" height="150"/>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Qan-4E-yVI">
+                                                <rect key="frame" x="107" y="0.0" width="200" height="150"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="200" id="I5B-OR-BOK"/>
-                                                    <constraint firstAttribute="height" constant="150" id="O7L-N7-bFl"/>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="I5B-OR-BOK"/>
+                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="150" id="O7L-N7-bFl"/>
+                                                    <constraint firstAttribute="width" secondItem="Qan-4E-yVI" secondAttribute="height" multiplier="4:3" id="iRX-wG-n1h"/>
                                                 </constraints>
                                             </imageView>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P6Q-Kz-bwu">
-                                                <rect key="frame" x="18.666666666666657" y="172" width="337.66666666666674" height="302"/>
+                                                <rect key="frame" x="20.5" y="172" width="373" height="302"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
@@ -317,8 +322,11 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="naq-Zb-3j7" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="f2I-lx-DrQ">
-                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <textAttributes key="titleTextAttributes">
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                        </textAttributes>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -183,11 +183,12 @@
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                     </preferredSymbolConfiguration>
                                                 </imageView>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="500" ambiguous="YES" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iFk-je-OfD">
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="500" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iFk-je-OfD">
                                                     <rect key="frame" x="15" y="9" width="73" height="54"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="73" id="0xe-QJ-ABb"/>
-                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="54" id="lwc-o4-U62"/>
+                                                        <constraint firstAttribute="width" secondItem="iFk-je-OfD" secondAttribute="height" multiplier="73:54" id="OZX-aV-3cV"/>
+                                                        <constraint firstAttribute="height" constant="54" id="lwc-o4-U62"/>
                                                     </constraints>
                                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="font" scale="large">
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="naq-Zb-3j7">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -13,67 +13,67 @@
             <objects>
                 <viewController id="uxu-vp-Ftd" customClass="ExpoIntroductionViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Rik-HV-13y">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2al-ah-QL5">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="XTp-P7-pb7">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="735.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="XTp-P7-pb7">
+                                        <rect key="frame" x="0.0" y="15" width="375" height="799.66666666666663"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W9n-k2-cQd">
-                                                <rect key="frame" x="20.5" y="0.0" width="373" height="33.5"/>
+                                                <rect key="frame" x="18.666666666666657" y="0.0" width="337.66666666666674" height="33.666666666666664"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="0Mm-LZ-6Jq">
-                                                <rect key="frame" x="142" y="49.5" width="130" height="182"/>
+                                                <rect key="frame" x="122.66666666666669" y="63.666666666666686" width="130" height="182"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="130" id="hlu-ZQ-FFr"/>
                                                     <constraint firstAttribute="height" constant="182" id="tG9-O7-WYm"/>
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q9r-Vv-YlV">
-                                                <rect key="frame" x="20.5" y="247.5" width="373" height="24"/>
+                                                <rect key="frame" x="18.666666666666657" y="275.66666666666669" width="337.66666666666674" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DGN-wd-zEG">
-                                                <rect key="frame" x="20.5" y="287.5" width="373" height="24"/>
+                                                <rect key="frame" x="18.666666666666657" y="329.66666666666669" width="337.66666666666674" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IBO-7c-rZz">
-                                                <rect key="frame" x="20.5" y="327.5" width="373" height="24"/>
+                                                <rect key="frame" x="18.666666666666657" y="383.66666666666669" width="337.66666666666674" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6PF-sP-6bm">
-                                                <rect key="frame" x="20.5" y="367.5" width="373" height="302"/>
+                                                <rect key="frame" x="18.666666666666657" y="437.66666666666674" width="337.66666666666674" height="302"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="DAv-k3-Cf2">
-                                                <rect key="frame" x="62" y="685.5" width="290" height="50"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="DAv-k3-Cf2">
+                                                <rect key="frame" x="18.666666666666657" y="769.66666666666663" width="337.66666666666674" height="30"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="AFB-51-Nxr">
-                                                        <rect key="frame" x="0.0" y="0.0" width="61.5" height="50"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="85.333333333333329" height="30"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="70" id="OcA-fl-gMj"/>
-                                                            <constraint firstAttribute="width" priority="750" constant="70" id="b4m-Os-V8Z"/>
-                                                            <constraint firstAttribute="height" constant="50" id="qFd-FT-E8J"/>
+                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="20" id="OcA-fl-gMj"/>
+                                                            <constraint firstAttribute="width" priority="750" constant="50" id="b4m-Os-V8Z"/>
+                                                            <constraint firstAttribute="height" constant="30" id="qFd-FT-E8J"/>
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="BaF-UW-Uca">
-                                                        <rect key="frame" x="71.5" y="0.0" width="147" height="50"/>
+                                                        <rect key="frame" x="95.333333333333314" y="0.0" width="147" height="30"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                         <state key="normal" title="한국의 출품작 보러가기"/>
                                                         <userDefinedRuntimeAttributes>
@@ -84,11 +84,11 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="UtQ-Ps-fb9">
-                                                        <rect key="frame" x="228.5" y="0.0" width="61.5" height="50"/>
+                                                        <rect key="frame" x="252.33333333333334" y="0.0" width="85.333333333333343" height="30"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="height" constant="50" id="94e-Xb-2G3"/>
+                                                            <constraint firstAttribute="height" constant="30" id="94e-Xb-2G3"/>
                                                             <constraint firstAttribute="width" priority="750" constant="70" id="WgN-d6-URw"/>
-                                                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="70" id="q3A-bP-qqv"/>
+                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="20" id="q3A-bP-qqv"/>
                                                         </constraints>
                                                     </imageView>
                                                 </subviews>
@@ -99,7 +99,7 @@
                                         </subviews>
                                         <constraints>
                                             <constraint firstItem="6PF-sP-6bm" firstAttribute="width" secondItem="XTp-P7-pb7" secondAttribute="width" multiplier="90%" id="JRr-kp-Nxf"/>
-                                            <constraint firstItem="DAv-k3-Cf2" firstAttribute="width" secondItem="XTp-P7-pb7" secondAttribute="width" multiplier="70%" id="N55-Nh-07Y"/>
+                                            <constraint firstItem="DAv-k3-Cf2" firstAttribute="width" secondItem="XTp-P7-pb7" secondAttribute="width" multiplier="90%" id="N55-Nh-07Y"/>
                                             <constraint firstItem="DGN-wd-zEG" firstAttribute="width" secondItem="W9n-k2-cQd" secondAttribute="width" id="Nx1-Uj-crX"/>
                                             <constraint firstItem="W9n-k2-cQd" firstAttribute="width" secondItem="XTp-P7-pb7" secondAttribute="width" multiplier="90%" id="S1g-vK-AX5"/>
                                             <constraint firstItem="IBO-7c-rZz" firstAttribute="width" secondItem="W9n-k2-cQd" secondAttribute="width" id="tQq-s9-Et8"/>
@@ -108,9 +108,9 @@
                                     </stackView>
                                 </subviews>
                                 <constraints>
+                                    <constraint firstItem="XTp-P7-pb7" firstAttribute="bottom" secondItem="Lw0-uS-Odh" secondAttribute="bottom" constant="-50" id="7aD-VV-hqV"/>
                                     <constraint firstItem="Lw0-uS-Odh" firstAttribute="leading" secondItem="XTp-P7-pb7" secondAttribute="leading" id="Fo7-ae-caL"/>
-                                    <constraint firstItem="XTp-P7-pb7" firstAttribute="top" secondItem="Lw0-uS-Odh" secondAttribute="top" id="fZH-Xm-6iU"/>
-                                    <constraint firstItem="XTp-P7-pb7" firstAttribute="bottom" secondItem="Lw0-uS-Odh" secondAttribute="bottom" id="gBj-cA-wyd"/>
+                                    <constraint firstItem="XTp-P7-pb7" firstAttribute="top" secondItem="Lw0-uS-Odh" secondAttribute="top" constant="15" id="fZH-Xm-6iU"/>
                                     <constraint firstItem="XTp-P7-pb7" firstAttribute="trailing" secondItem="Lw0-uS-Odh" secondAttribute="trailing" id="m9x-3R-pJm"/>
                                     <constraint firstItem="XTp-P7-pb7" firstAttribute="centerX" secondItem="2al-ah-QL5" secondAttribute="centerX" id="xPt-As-QGI"/>
                                 </constraints>
@@ -148,39 +148,49 @@
             <objects>
                 <viewController id="6nj-jU-mX6" customClass="ArtworksTableViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="YOK-4Z-Nz7">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="iAO-ZJ-Agr">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="778"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="artworkTableViewCell" id="x5F-zN-2I4" customClass="ArtworkTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="72"/>
+                                        <rect key="frame" x="0.0" y="28" width="375" height="71.666664123535156"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="x5F-zN-2I4" id="DN2-Xb-7dX">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="72"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="71.666664123535156"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DvP-hq-pfF">
-                                                    <rect key="frame" x="103" y="8" width="269" height="27"/>
+                                                    <rect key="frame" x="89.333333333333329" y="8" width="243.66666666666669" height="27"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.right" catalog="system" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="V9A-UB-hih">
-                                                    <rect key="frame" x="386.5" y="28" width="12.5" height="16.5"/>
+                                                    <rect key="frame" x="347.66666666666669" y="22" width="12.333333333333314" height="28.000000000000004"/>
                                                     <color key="tintColor" systemColor="placeholderTextColor"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="12.5" id="2Tv-Vj-Vmh"/>
+                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="jRN-d2-cHt"/>
+                                                    </constraints>
+                                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="font">
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                    </preferredSymbolConfiguration>
                                                 </imageView>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="iFk-je-OfD">
-                                                    <rect key="frame" x="15" y="9" width="73" height="54"/>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="500" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iFk-je-OfD">
+                                                    <rect key="frame" x="15.000000000000004" y="9" width="59.333333333333343" height="54"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="73" id="0xe-QJ-ABb"/>
                                                         <constraint firstAttribute="height" constant="54" id="lwc-o4-U62"/>
                                                     </constraints>
+                                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="font" scale="large">
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                    </preferredSymbolConfiguration>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="500" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N0K-GJ-zUp">
-                                                    <rect key="frame" x="103" y="44.5" width="269" height="19.5"/>
+                                                    <rect key="frame" x="89.333333333333329" y="44.333333333333336" width="243.66666666666669" height="19.333333333333336"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -241,24 +251,24 @@
             <objects>
                 <viewController storyboardIdentifier="ArtworkDetailViewController" id="1Bi-c2-xrB" customClass="ArtworkDetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="uEi-kp-6rg">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jfZ-fw-sye">
-                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
+                                <rect key="frame" x="0.0" y="88" width="375" height="724"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="22" translatesAutoresizingMaskIntoConstraints="NO" id="FNa-JS-dAG">
-                                        <rect key="frame" x="0.0" y="20" width="414" height="474"/>
+                                        <rect key="frame" x="0.0" y="20" width="375" height="474"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Qan-4E-yVI">
-                                                <rect key="frame" x="107" y="0.0" width="200" height="150"/>
+                                                <rect key="frame" x="87.666666666666686" y="0.0" width="200" height="150"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="200" id="I5B-OR-BOK"/>
                                                     <constraint firstAttribute="height" constant="150" id="O7L-N7-bFl"/>
                                                 </constraints>
                                             </imageView>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P6Q-Kz-bwu">
-                                                <rect key="frame" x="20.5" y="172" width="373" height="302"/>
+                                                <rect key="frame" x="18.666666666666657" y="172" width="337.66666666666674" height="302"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
@@ -307,7 +317,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="naq-Zb-3j7" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="f2I-lx-DrQ">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>


### PR DESCRIPTION
## 지난 Step 코멘트 답변
1. `tableView.indexPath(for:)` 메서드라는 것이 있다!
![image](https://user-images.githubusercontent.com/69730931/114998817-47d3f900-9edc-11eb-8870-24bd532efacc.png)

지난 리뷰 덕분에 `indexPath`를 획득하는 방식을 더 나은 방식으로 변경할 수 있었어요. 지난 시간에 학습한 `LLDB`를 활용해서 `sender`가 무엇인지 확인해봤어요. 결과적으로 `sender`는 해당 메서드를 실행시키는 주체(이 메서드의 경우 segue)를 나타내는 것으로 확인하였습니다. 이 경우에는 `UITableViewCell` 타입이고 `indexPath`를 가지고 있어 아래와 같이 코드를 변경했어요.
```swift
override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
  guard let indexPath = tableView.indexPath(for: sender as! UITableViewCell) else {
    os_log(.fault, log: .ui, OSLogMessage.indexPathIsNil)
    return
  }
  
  if segue.identifier == Identifier.Segue.artworkDetail {
    let followingViewController = segue.destination as? ArtworkDetailViewController
    
    followingViewController?.artwork = artworks[indexPath.row]
  }
}
```

## 지난 PR 미결 사항
1. 지난 리뷰에서 `os_log` 메서드에 대해 [질문](https://github.com/yagom-academy/ios-exposition-universelle/pull/60#discussion_r612699905)을 드렸었어요. 요점은 메시지 타입으로 `StaticString`만을 사용할 수 있어 작성한 에러타입을 활용해서 로그를 남길 수 없었다는 내용인데요, `os_log`를 사용하려면 `associated value`를 적용한 `enum`과 달리 매 번 `StaticString`으로 정의된 메시지를 따로 만들어주어야 하나요?
![image](https://user-images.githubusercontent.com/69730931/115003594-ebbfa380-9ee0-11eb-9361-118a48fea56f.png)

## 실행 화면
font size를 `accessibility inspector`를 이용해 크고 작게 설정하여 Dynamic type 적용을 확인했습니다.
큰 화면을 가진 `iPhone 11 (좌)`와 작은 화면을 가진 `iPhone SE 2세대 (우)`를 통해 여러 기기에서 오토레이아웃이 정상적으로 동작하는지 확인하였습니다.

<img width="379" alt="Screen Shot 2021-04-16 at 4 44 49 PM" src="https://user-images.githubusercontent.com/69730931/114995151-7cde4c80-9ed8-11eb-801a-860c91d4d6e6.png"><img width="376" alt="Screen Shot 2021-04-16 at 4 45 26 PM" src="https://user-images.githubusercontent.com/69730931/114995289-a13a2900-9ed8-11eb-91f5-bd666c630408.png">
<img width="377" alt="Screen Shot 2021-04-16 at 4 45 56 PM" src="https://user-images.githubusercontent.com/69730931/114995287-a13a2900-9ed8-11eb-90ee-d4e347979e99.png"><img width="379" alt="Screen Shot 2021-04-16 at 4 46 25 PM" src="https://user-images.githubusercontent.com/69730931/114995285-a0a19280-9ed8-11eb-9954-141086fbdd29.png">
<img width="376" alt="Screen Shot 2021-04-16 at 4 46 56 PM" src="https://user-images.githubusercontent.com/69730931/114995284-a008fc00-9ed8-11eb-9a72-79f545797a51.png"><img width="376" alt="Screen Shot 2021-04-16 at 4 47 26 PM" src="https://user-images.githubusercontent.com/69730931/114995282-a008fc00-9ed8-11eb-893e-614192b3fc04.png">
<img width="378" alt="Screen Shot 2021-04-16 at 4 47 46 PM" src="https://user-images.githubusercontent.com/69730931/114995281-9f706580-9ed8-11eb-8c83-42400194c2db.png"><img width="378" alt="Screen Shot 2021-04-16 at 4 48 05 PM" src="https://user-images.githubusercontent.com/69730931/114995279-9ed7cf00-9ed8-11eb-857d-77a0f5b9b681.png">

<img width="767" alt="Screen Shot 2021-04-16 at 4 52 44 PM" src="https://user-images.githubusercontent.com/69730931/114995277-9e3f3880-9ed8-11eb-9419-7ede49fe4401.png">
<img width="765" alt="Screen Shot 2021-04-16 at 4 53 07 PM" src="https://user-images.githubusercontent.com/69730931/114995276-9da6a200-9ed8-11eb-91e2-69e7a33b2500.png">
<img width="768" alt="Screen Shot 2021-04-16 at 4 53 41 PM" src="https://user-images.githubusercontent.com/69730931/114995274-9c757500-9ed8-11eb-822a-aa088d29ac88.png">
<img width="768" alt="Screen Shot 2021-04-16 at 4 54 11 PM" src="https://user-images.githubusercontent.com/69730931/114995255-997a8480-9ed8-11eb-8c74-ce7971b3c06b.png">

초기 화면은 세로로만 실행
![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/69730931/114994969-51f3f880-9ed8-11eb-94c9-cafa8e2587c9.gif)

화면을 가로로 들고 있을 경우 초기화면에서 다음 화면으로 넘어가면 가로모드로 변경, 다시 초기화면으로 복귀하면 세로화면만 지원 
![ezgif com-resize (1)](https://user-images.githubusercontent.com/69730931/114994384-afd41080-9ed7-11eb-961f-3c33618d67a6.gif)

## STEP 3 요구기능 구현 관련

### 1. 첫 화면(ExpoIntroductionViewController`)은 세로로만 볼 수 있도록 설정하였습니다.
#### 마주했던 문제:
- 시작 뷰 컨트롤러의 `supportedInterfaceOrientation` 프로퍼티를 이용하여 앱 시작 시 화면 방향을 `portrait`으로 고정하고 화면 회전이 되지 않게 `shouldAutoRotate`를 `false`로 지정하였지만, 기기를 가로로 들고 앱을 시작할 경우 가로모드로 실행되어 회전되지 않는 문제가 있었습니다.
- 이를 아래와 같은 방법으로 해결하고자 하였으나, `shouldAutoRotate` 프로퍼티가 `false`이기에`UINavigationController.attemptRotationToDeviceOrientation()`이 작동되지 않는 문제가 있었습니다.
```swift
final class ExpoIntroductionViewController: UIViewController {
  // MARK: - Properties
  // 화면 회전 불가, 선호 및 지원 방향 설정
  override var shouldAutorotate: Bool { return false }
  override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation { return .portrait }
  override var supportedInterfaceOrientations: UIInterfaceOrientationMask { return .portrait }

  // MARK: - View Life Cycle
  override func viewWillAppear(_ animated: Bool) {
    // 기기의 방향을 선호 방향으로 설정하여 기기 선호 방향으로 회전
    UIDevice.setValue(preferredInterfaceOrientationForPresentation.rawValue, forKey: "orientation")
    UINavigationController.attemptRotationToDeviceOrientation()
  }
}
```
#### 해결 방법 (feat. Neph 👏):
- 앱 시작 시 가로모드로 시작되지 않도록 `Deployment Info`의 `Device Orientation` 설정을 `portrait`으로 제한하고, `AppDelegate`의 `application(_:supportedInterfaceOrientationFor:) -> UIInterfaceOrientationMask` 메서드를 이용해 각 화면에서 지원하는 방향을 다시 알려주는 방식으로 해결했습니다. 
```swift
@main
class AppDelegate: UIResponder, UIApplicationDelegate {
  var shouldSupportAllOrientation: Bool = false
  
  func application(
    _ application: UIApplication,
    supportedInterfaceOrientationsFor window: UIWindow?
  ) -> UIInterfaceOrientationMask {
    if shouldSupportAllOrientation == true {
      return  .allButUpsideDown
    }
    return .portrait
  }

final class ExpoIntroductionViewController: UIViewController {
  // MARK: - Properties
  override var shouldAutorotate: Bool { return false }
  override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation { return .portrait }
  override var supportedInterfaceOrientations: UIInterfaceOrientationMask { return .portrait }
  private let appDelegate = UIApplication.shared.delegate as! AppDelegate

  // MARK: - View Life Cycle
  override func viewWillAppear(_ animated: Bool) {
    appDelegate.shouldSupportAllOrientation = false
  }
  
  override func viewWillDisappear(_ animated: Bool) {
    appDelegate.shouldSupportAllOrientation = true
  }
}
```

### 2. 출품작 목록과 상세 두 화면 모두 가로로 회전했을 때도 정상적으로 표시될 수 있도록 구현하였습니다.
### 3. 모든 화면은 모든 아이폰 기기(아이패드 제외) 크기에 맞도록 구현했습니다.
- 오토레이아웃을 이용하여 모든 iPhone 기기의 크기 안에 컨텐츠가 들어갈 수 있도록 구성했습니다.

### 4. 모든 화면에 Dynamic Type을 적용하였습니다.
- 모든 Label과 TextView에 dynamic type font를 적용하고 `Automatically Adjusts Font` 기능을 활성화하였습니다.
- ImageView는 `Accessibility`의 `Adjusts Image Size` 기능을 활성화하고 최소 너비 및 높이와 비율을 설정하여 폰트 크기 변화에 대응할 수 있도록 구성하였습니다.
- TableViewCell 내 ImageView는 폰트 크기에 대응하게 설정할 경우 테이블 뷰의 레이아웃 정렬이 다소 흐트러져 dynamic type을 적용하지 않았습니다.

#### 해결하지 못한 문제
- `NavigationBar`의 `title`에 dynamic type font를 적용하였더니 2세대 iPhone SE에서 타이틀이 잘려 보이는 문제가 있습니다. 
<img width="765" alt="Screen Shot 2021-04-16 at 4 53 07 PM" src="https://user-images.githubusercontent.com/69730931/114995276-9da6a200-9ed8-11eb-91e2-69e7a33b2500.png">
- 아직 해결하지 못했는데, `additionalSafeAreaInsets`에 대해 알아보면 될까요?

### 5. 세로, 가로 방향, 모든 폰트 크기에 대응할 수 있도록 오토 레이아웃을 구성하여 모든 텍스트가 잘리거나 줄임표(...) 처리가 되지 않도록 구성하였습니다.

## 조언을 얻고 싶은 부분
1. [야곰의 코멘트](https://github.com/yagom-academy/ios-exposition-universelle/pull/63#discussion_r611663011)를 보고 초기 화면의 `titleLabel`의 개행 방식을 아래와 같이 설정해봤어요. 박람회가 박람전이나 전시회가 된다든지 여전히 기획 변경에 의해 문구가 바뀌면 코드도 수정되어야 할 것 같은데 좋은 방법이 있을까요? @stevenkim18
```swift
titleLabel.text = titleLabel.text?.replacingOccurrences(of: "박람회 1900", with: "박람회 1900\n")
```

